### PR TITLE
Add k8s limits

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -20,7 +20,7 @@ spec:
           resources:
             requests:
               memory: "150Mi"
-              cpu: "300m"
+              cpu: "150m"
             limits:
               memory: "300Mi"
               cpu: "500m"

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -17,5 +17,12 @@ spec:
       containers:
         - name: thumbnailer-nginx
           image: zooniverse/thumbnailer:__IMAGE_TAG__
+          resources:
+            requests:
+              memory: "150Mi"
+              cpu: "300m"
+            limits:
+              memory: "300Mi"
+              cpu: "500m"
           ports:
             - containerPort: 80


### PR DESCRIPTION
90th percentile memory usage is under a hundred megs, but the max is around 285Mi. So I set the requested to 150Mi, but the limit to 300 to let it burst to that amount. 

I think that's how this is supposed to work.