### PR TITLE
Allow thumbnails from non static buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # thumbnailer
 
-Generates on-demand thumbnails of images from the zoo static S3 bucket
+Generates on-demand thumbnails of images from the zoo
+owned S3 buckets, currently these buckets are allowed:
+
+1. zooniverse-static
+2. www.galaxyzoo.org
 
 E.g.
 http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.zooniverse.org/291a76c92e4335f7e3a0bed53af6a7bf.jpg

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # thumbnailer
+
 Generates on-demand thumbnails of images from the zoo static S3 bucket
 
-E.g. 
+E.g.
 http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.zooniverse.org/291a76c92e4335f7e3a0bed53af6a7bf.jpg
 https://thumbnails.zooniverse.org/400x200/www.zooniverse.org/291a76c92e4335f7e3a0bed53af6a7bf.jpg
+
+## Testing
+
+1. `docker-compose build`
+2. `docker-compose up`
+
+``` bash
+# media hosted in zooniverse-static bucket
+curl -vv localhost:8080/400x200/www.zooniverse.org/291a76c92e4335f7e3a0bed53af6a7bf.jpg
+
+# media hosted in www.galaxyzoo.org bucket
+curl -vv  localhost:8080/150x150/www.galaxyzoo.org.s3.amazonaws.com/subjects/standard/1237646586100384096.jpg
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  thumbnailer:
+    build:
+      context:  ./
+      dockerfile: Dockerfile
+    ports:
+      - "8080:80"

--- a/nginx.conf
+++ b/nginx.conf
@@ -53,7 +53,6 @@ http {
             resolver 8.8.8.8;
             proxy_pass http://zooniverse-static.s3-website-us-east-1.amazonaws.com$uri?$query_string;
             proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
-            add_header X-debug-message "default - http://zooniverse-static.s3-website-us-east-1.amazonaws.com${uri}?${query_string}" always;
             image_filter_buffer 10M;
             image_filter resize $width $height;
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,11 +35,25 @@ http {
             set $height $2;
         }
 
+        # proxy zooniverse owned non-static buckets to their relevant cloud object store URL
+        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/www.galaxyzoo.org.s3.amazonaws.com/.+$" {
+            rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/www.galaxyzoo.org.s3.amazonaws.com)(/.*)$" $3 break;
+            resolver 8.8.8.8;
+            # ensure we do not pass to the regional virtual host style URL as that is
+            # a 302 redirect as configured in https://s3.console.aws.amazon.com/s3/buckets/www.galaxyzoo.org/?region=us-east-1&tab=properties
+            proxy_pass http://www.galaxyzoo.org.s3.amazonaws.com$uri?$query_string;
+            proxy_set_header       Host www.galaxyzoo.org.s3.amazonaws.com;
+            image_filter_buffer 10M;
+            image_filter resize $width $height;
+        }
+
+        # proxy all other requests to the static
         location / {
             rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/.*)$" $2 break;
             resolver 8.8.8.8;
             proxy_pass http://zooniverse-static.s3-website-us-east-1.amazonaws.com$uri?$query_string;
             proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
+            add_header X-debug-message "default - http://zooniverse-static.s3-website-us-east-1.amazonaws.com${uri}?${query_string}" always;
             image_filter_buffer 10M;
             image_filter resize $width $height;
         }


### PR DESCRIPTION
Allow www.galaxyzoo.org bucket to have thumbnails generated for it. This is required for the static talk archive pages to work as these images are not hosted in the zooniverse-static bucket paths.

Noting that using regional virtual host url has a redirect configured, e.g. `http://www.galaxyzoo.org.s3-website-us-east-1.amazonaws.com$uri?$query_string;` whereas non regional virtual host works ok `http://www.galaxyzoo.org.s3.amazonaws.com$uri?$query_string;`