### PR TITLE
relax domain matching rules for www.galaxyzoo.org bucket paths

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -36,8 +36,8 @@ http {
         }
 
         # proxy zooniverse owned non-static buckets to their relevant cloud object store URL
-        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/www.galaxyzoo.org.s3.amazonaws.com/.+$" {
-            rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/www.galaxyzoo.org.s3.amazonaws.com)(/.*)$" $3 break;
+        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/www.galaxyzoo.org(?:.s3.amazonaws.com)*/.+$" {
+            rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/www.galaxyzoo.org(?:.s3.amazonaws.com)*)(/.*)$" $3 break;
             resolver 8.8.8.8;
             # ensure we do not pass to the regional virtual host style URL as that is
             # a 302 redirect as configured in https://s3.console.aws.amazon.com/s3/buckets/www.galaxyzoo.org/?region=us-east-1&tab=properties


### PR DESCRIPTION
sometimes the domain path is www.galaxyzoo.org.s3.amazonaws.com other times it is
www.galaxyzoo.org this relaxes the location match and ensure we rewrite the paths to remote s3 proxy correctly.