### PR TITLE
Proxy panoptes-uploads to Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Generates on-demand thumbnails of images from the zoo
 owned Azure blob storage and (currently) specific S3 buckets. These buckets are allowed:
 
-1. panoptesuploads (Azure storage account)
-2. www.galaxyzoo.org (S3 bucket)
+1. panoptesuploads (Azure storage account, `public` container)
+2. www.galaxyzoo.org (S3 bucket, legacy)
+3. Anything else will be proxied to S3, for other cases that aren't in panoptesuploads (e.g. sciencegossip)
 
 E.g.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # thumbnailer
 
 Generates on-demand thumbnails of images from the zoo
-owned S3 buckets, currently these buckets are allowed:
+owned Azure blob storage and (currently) specific S3 buckets. These buckets are allowed:
 
-1. zooniverse-static
-2. www.galaxyzoo.org
+1. panoptesuploads (Azure storage account)
+2. www.galaxyzoo.org (S3 bucket)
 
 E.g.
-http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.zooniverse.org/291a76c92e4335f7e3a0bed53af6a7bf.jpg
-https://thumbnails.zooniverse.org/400x200/www.zooniverse.org/291a76c92e4335f7e3a0bed53af6a7bf.jpg
+
+https://panoptesuploads.blob.core.windows.net/public/tutorial_attached_image/00029b92-9b79-4838-8aa0-983b2965a691.png
+
+-->
+
+https://thumbnails.zooniverse.org/400x200/tutorial_attached_image/00029b92-9b79-4838-8aa0-983b2965a691.png
 
 ## Testing
 
@@ -17,7 +21,7 @@ https://thumbnails.zooniverse.org/400x200/www.zooniverse.org/291a76c92e4335f7e3a
 
 ``` bash
 # media hosted in zooniverse-static bucket
-curl -vv localhost:8080/400x200/www.zooniverse.org/291a76c92e4335f7e3a0bed53af6a7bf.jpg
+curl -vv localhost:8080/400x200/tutorial_attached_image/00029b92-9b79-4838-8aa0-983b2965a691.png
 
 # media hosted in www.galaxyzoo.org bucket
 curl -vv  localhost:8080/150x150/www.galaxyzoo.org.s3.amazonaws.com/subjects/standard/1237646586100384096.jpg

--- a/nginx.conf
+++ b/nginx.conf
@@ -51,8 +51,8 @@ http {
         location / {
             rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/.*)$" $2 break;
             resolver 8.8.8.8;
-            proxy_pass http://zooniverse-static.s3-website-us-east-1.amazonaws.com$uri?$query_string;
-            proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
+            proxy_pass https://panoptesuploads.blob.core.windows.net/public$uri?$query_string;
+            proxy_set_header       Host panoptesuploads.blob.core.windows.net;
             image_filter_buffer 10M;
             image_filter resize $width $height;
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -47,12 +47,22 @@ http {
             image_filter resize $width $height;
         }
 
-        # proxy all other requests to the static
-        location / {
-            rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/.*)$" $2 break;
+        # Proxy panoptes-uploads requests to Azure storage
+        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/.+$" {
+            rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/panoptes-uploads.zooniverse.org)(/.*)$" $3 break;
             resolver 8.8.8.8;
             proxy_pass https://panoptesuploads.blob.core.windows.net/public$uri?$query_string;
             proxy_set_header       Host panoptesuploads.blob.core.windows.net;
+            image_filter_buffer 10M;
+            image_filter resize $width $height;
+        }
+
+        # proxy all other requests to the AWS
+        location / {
+            rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/.*)$" $2 break;
+            resolver 8.8.8.8;
+            proxy_pass http://zooniverse-static.s3-website-us-east-1.amazonaws.com$uri?$query_string;
+            proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
             image_filter_buffer 10M;
             image_filter resize $width $height;
         }


### PR DESCRIPTION
Three cases in here, now: galaxyzoo.org, panoptes-uploads, and the reset. The former and the later both proxy to S3 for legacy reasons. The second causes anything URL that contains `panoptes-uploads.zooniverse.org` to proxy to the Azure panoptesuploads storage account's `public` container. 