### PR TITLE
Remove gz proxy from thumbnails nginx server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Generates on-demand thumbnails of images from the zoo
 owned Azure blob storage and (currently) specific S3 buckets. These buckets are allowed:
 
 1. panoptesuploads (Azure storage account, `public` container)
-2. www.galaxyzoo.org (S3 bucket, legacy)
-3. Anything else will be proxied to S3, for other cases that aren't in panoptesuploads (e.g. sciencegossip)
+2. Anything else will be proxied to S3, for other cases that aren't in panoptesuploads (e.g. www.sciencegossip.org, www.galaxyzoo.org)
+    + https://thumbnails.zooniverse.org/100x100/www.sciencegossip.org/subjects/thumb/54f43a24efc50104c30007d9.jpg
+    + https://thumbnails.zooniverse.org/100x100/www.galaxyzoo.org/subjects/thumbnail/56f3dff05925d90043004e21.jpeg
 
 E.g.
 
@@ -23,7 +24,4 @@ https://thumbnails.zooniverse.org/400x200/tutorial_attached_image/00029b92-9b79-
 ``` bash
 # media hosted in zooniverse-static bucket
 curl -vv localhost:8080/400x200/tutorial_attached_image/00029b92-9b79-4838-8aa0-983b2965a691.png
-
-# media hosted in www.galaxyzoo.org bucket
-curl -vv  localhost:8080/150x150/www.galaxyzoo.org.s3.amazonaws.com/subjects/standard/1237646586100384096.jpg
 ```

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,18 +35,6 @@ http {
             set $height $2;
         }
 
-        # proxy zooniverse owned non-static buckets to their relevant cloud object store URL
-        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/www.galaxyzoo.org.s3.amazonaws.com/.+$" {
-            rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/www.galaxyzoo.org.s3.amazonaws.com)(/.*)$" $3 break;
-            resolver 8.8.8.8;
-            # ensure we do not pass to the regional virtual host style URL as that is
-            # a 302 redirect as configured in https://s3.console.aws.amazon.com/s3/buckets/www.galaxyzoo.org/?region=us-east-1&tab=properties
-            proxy_pass http://www.galaxyzoo.org.s3.amazonaws.com$uri?$query_string;
-            proxy_set_header       Host www.galaxyzoo.org.s3.amazonaws.com;
-            image_filter_buffer 10M;
-            image_filter resize $width $height;
-        }
-
         # Proxy panoptes-uploads requests to Azure storage
         location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/.+$" {
             rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/panoptes-uploads.zooniverse.org)(/.*)$" $3 break;


### PR DESCRIPTION
the `www.galaxyzoo.org.s3.amazonaws.com` urls aren't used in the archived talk site since https://github.com/zooniverse/Talk-archiver/pull/81

Instead they use the direct `www.galaxyzoo.org` urls which are handled by the static nginx server to redirect to azure, https://github.com/zooniverse/static/blob/7bf1adf0e21f7ca4f0999be8439dd97dd51b5bd7/sites/www.galaxyzoo.org.conf#L9-L12

As such we can remove this location block from the thumbnailer service as it's not in use.