### PR TITLE
Proxy to azure for default requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ owned Azure blob storage and (currently) specific S3 buckets. These buckets are 
 
 1. panoptesuploads (Azure storage account, `public` container)
 2. www.galaxyzoo.org (S3 bucket, legacy)
-3. Anything else will be proxied to S3, for other cases that aren't in panoptesuploads (e.g. sciencegossip)
+3. All other paths will be proxied to Azure `zooniversestatic` storage account in the `$web` container (e.g. www.sciencegossip.org)
 
-E.g.
+E.g. the following URL
+
+https://thumbnails.zooniverse.org/400x200/panoptes-uploads.zooniverse.org/tutorial_attached_image/00029b92-9b79-4838-8aa0-983b2965a691.png
+
+proxies to the upstream URL -->
 
 https://panoptesuploads.blob.core.windows.net/public/tutorial_attached_image/00029b92-9b79-4838-8aa0-983b2965a691.png
-
--->
-
-https://thumbnails.zooniverse.org/400x200/tutorial_attached_image/00029b92-9b79-4838-8aa0-983b2965a691.png
 
 ## Testing
 
@@ -21,8 +21,12 @@ https://thumbnails.zooniverse.org/400x200/tutorial_attached_image/00029b92-9b79-
 2. `docker-compose up`
 
 ``` bash
-# media hosted in zooniverse-static bucket
-curl -vv localhost:8080/400x200/tutorial_attached_image/00029b92-9b79-4838-8aa0-983b2965a691.png
+
+# media hosted in azure zooniversestatic storage account $web container
+curl -vv localhost:8080/400x200/www.zooniverse.org/291a76c92e4335f7e3a0bed53af6a7bf.jpg
+
+# media hosted in the azure panoptes-uploads storage account public container
+curl -vv localhost:8080/400x200/panoptes-uploads.zooniverse.org/tutorial_attached_image/00029b92-9b79-4838-8aa0-983b2965a691.png
 
 # media hosted in www.galaxyzoo.org bucket
 curl -vv  localhost:8080/150x150/www.galaxyzoo.org.s3.amazonaws.com/subjects/standard/1237646586100384096.jpg

--- a/nginx.conf
+++ b/nginx.conf
@@ -76,7 +76,7 @@ http {
             rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/.*)$" $2 break;
             resolver 8.8.8.8;
             proxy_http_version 1.1;
-            proxy_pass https://zooniversestatic.z13.web.core.windows.net$uri;
+            proxy_pass https://zooniversestatic.z13.web.core.windows.net$uri?$query_string;
             proxy_set_header   Host zooniversestatic.z13.web.core.windows.net;
             image_filter_buffer 10M;
             image_filter resize $width $height;

--- a/nginx.conf
+++ b/nginx.conf
@@ -59,12 +59,13 @@ http {
             image_filter resize $width $height;
         }
 
-        # proxy all other requests to the AWS
+        # proxy all other requests to the azure zoonversestatic storage account, $web container
         location / {
             rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/.*)$" $2 break;
             resolver 8.8.8.8;
-            proxy_pass http://zooniverse-static.s3-website-us-east-1.amazonaws.com$uri?$query_string;
-            proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
+            proxy_http_version 1.1;
+            proxy_pass https://zooniversestatic.z13.web.core.windows.net$uri;
+            proxy_set_header   Host zooniversestatic.z13.web.core.windows.net;
             image_filter_buffer 10M;
             image_filter resize $width $height;
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,8 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     access_log  /dev/stdout  main;
+    # use debug level to debug proxy pass, rewrites and other nginx internals
+    # error_log /dev/stderr debug;
 
     sendfile        on;
     #tcp_nopush     on;


### PR DESCRIPTION
closes #18 

By default proxy all requests to the azure `zoonviersestatic` storage account `$web` container. This should be a mirror of the s3 `zooniverse-static` bucket. 

Before deploying this, the static bucket will need a resync to azure storage to ensure the latest set of files are copied from s3 to azure , https://github.com/zooniverse/operations/wiki/Adam%27s-Handover-Notes#AWSS3_to_Azure_data_sync