### PR TITLE
fix thumbnailer service for panoptes-uploads domain

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,7 +47,19 @@ http {
             image_filter resize $width $height;
         }
 
-        # Proxy panoptes-uploads staging requests to Azure storage
+        # Proxy new panoptes-uploads-staging requests to Azure storage
+        # e.g. https://panoptes-uploads-staging.zooniverse.org/workflow_attached_image/704a79c1-e728-4ab3-828d-e398fba69ec3.jpeg
+        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads-staging.zooniverse.org/.+$" {
+            rewrite "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads-staging.zooniverse.org(/.*)$" $1 break;
+            resolver 8.8.8.8;
+            proxy_pass https://panoptesuploadsstaging.blob.core.windows.net/public$uri?$query_string;
+            proxy_set_header       Host panoptesuploadsstaging.blob.core.windows.net;
+            image_filter_buffer 10M;
+            image_filter resize $width $height;
+        }
+
+        # Proxy old panoptes-uploads staging requests to Azure storage
+        # e.g. https://panoptes-uploads.zooniverse.org/staging/workflow_attached_image/362d0a60-84a1-41db-9ea9-a42789f492c8.jpeg
         location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/staging/.+$" {
             rewrite "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/staging(/.*)$" $1 break;
             resolver 8.8.8.8;
@@ -58,8 +70,10 @@ http {
         }
 
         # Proxy panoptes-uploads production requests to Azure storage
-        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/production/.+$" {
-            rewrite "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/production(/.*)$" $1 break;
+        # e.g. https://panoptes-uploads.zooniverse.org/production/workflow_attached_image/c3303c4d-28b2-453c-882c-63a95a5c41bc.jpeg
+        #      https://panoptes-uploads.zooniverse.org/workflow_attached_image/6769554f-9079-41c8-acfc-393737a4972f.jpeg
+        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/.+$" {
+            rewrite "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org(?:/production)?(/.*)$" $1 break;
             resolver 8.8.8.8;
             proxy_pass https://panoptesuploads.blob.core.windows.net/public$uri?$query_string;
             proxy_set_header       Host panoptesuploads.blob.core.windows.net;

--- a/nginx.conf
+++ b/nginx.conf
@@ -47,9 +47,19 @@ http {
             image_filter resize $width $height;
         }
 
-        # Proxy panoptes-uploads requests to Azure storage
-        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/.+$" {
-            rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/panoptes-uploads.zooniverse.org)(/.*)$" $3 break;
+        # Proxy panoptes-uploads staging requests to Azure storage
+        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/staging/.+$" {
+            rewrite "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/staging(/.*)$" $1 break;
+            resolver 8.8.8.8;
+            proxy_pass https://panoptesuploadsstaging.blob.core.windows.net/public$uri?$query_string;
+            proxy_set_header       Host panoptesuploadsstaging.blob.core.windows.net;
+            image_filter_buffer 10M;
+            image_filter resize $width $height;
+        }
+
+        # Proxy panoptes-uploads production requests to Azure storage
+        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/production/.+$" {
+            rewrite "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/production(/.*)$" $1 break;
             resolver 8.8.8.8;
             proxy_pass https://panoptesuploads.blob.core.windows.net/public$uri?$query_string;
             proxy_set_header       Host panoptesuploads.blob.core.windows.net;


### PR DESCRIPTION
Closes https://github.com/zooniverse/Panoptes-Front-End/issues/5867 and https://github.com/zooniverse/Panoptes-Front-End/issues/5869 

AWS URLs were all hosted in the same bucket, e.g. `panoptes-uploads.zooniverse.org` and the path string e.g. `/production/` determined the location of the actual image resource. However in azure we now have different storage accounts (1 prod, 1 staging) and thus we need to change the target `proxy_pass` url correctly AND remove the env path string e.g. remove `/production` from `panoptes-uploads.zooniverse.org/production/`.

This PR splits out the staging URLs and proxies them to the correct azure storage account URL and paths and removes the `production` path string from production url paths. 

Tested locally using the following URLs harvested from staging & production projects
```
# new style staging URLs with correct domain / path
curl -vv --output - localhost:8080/500x500/panoptes-uploads-staging.zooniverse.org/workflow_attached_image/704a79c1-e728-4ab3-828d-e398fba69ec3.jpeg

# old style staging URLs with the staging env in the path **note using panoptes-uploads.zooniverse.org**
curl -vv --output - localhost:8080/500x500/panoptes-uploads.zooniverse.org/staging/workflow_attached_image/362d0a60-84a1-41db-9ea9-a42789f492c8.jpeg

# old style production URLs with production env in the path
curl -vv --output - localhost:8080/500x500/panoptes-uploads.zooniverse.org/production/workflow_attached_image/c3303c4d-28b2-453c-882c-63a95a5c41bc.jpeg

# new style production URLs with correct domain / path 
curl -vv --output - localhost:8080/500x500/panoptes-uploads.zooniverse.org/workflow_attached_image/6769554f-9079-41c8-acfc-393737a4972f.jpeg
```