### PR TITLE
avoid preemptive autoscaling events

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -19,10 +19,10 @@ spec:
           resources:
             requests:
               memory: "150Mi"
-              cpu: "250m"
+              cpu: "500m"
             limits:
               memory: "1000Mi"
-              cpu: "500m"
+              cpu: "1000m"
           ports:
             - containerPort: 80
 ---
@@ -35,6 +35,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: thumbnailer
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 6
   targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
Currently the thumbnailer scales up and down frequently due to the current traffic patterns and the low cpu request limit compared to the target CPU utilitization 80% of 0.25vCPU

This PR aims to stabilize the service's pod counts and decrease the number of autoscaling events in on the k8s cluster, in particular it 

- run 2 pods by default
- increase the cpu request to 0.5 vCPU and allow cpu to burst to 1 vCPU
- switches the target cpu for scaling events from 0.2 vcpu to 0.4vCPU for each pod (considering we will have 2 pods this should split the traffic / cpu work on each pod)