### PR TITLE
add proxy cache setup for thumbnail images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM nginx:alpine
 
+RUN mkdir -p /nginx-cache/
+
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -27,11 +27,18 @@ http {
     # error_log /dev/stderr debug;
 
     sendfile        on;
-    #tcp_nopush     on;
+    tcp_nopush     on;
 
     keepalive_timeout  65;
 
+    proxy_cache_path  /nginx-cache/  levels=1:2 keys_zone=STATIC:10m  max_size=500m;
+
     server {
+        # use the nginx proxy cache defined above in HTTP block
+        proxy_cache            STATIC;
+        proxy_cache_valid      200  1d;
+        proxy_cache_use_stale  error timeout invalid_header updating http_500 http_502 http_503 http_504;
+
         if ($uri ~ "^/([1-9][0-9]{0,2})x([1-9][0-9]{0,2})/") {
             set $width $1;
             set $height $2;


### PR DESCRIPTION
attempt to do less upstream proxying, instead add a response caching system and serve from here for actively requested files

this setup mimics the proxy cache in static system https://github.com/zooniverse/static/blob/b999da11e99e340c1c7cb3523e1225e163839c90/nginx.conf#L65 but uses a smaller `max_size` cache at 500m and the default 10min inactivity period. 

This should speed up thumbnail images that are frequently requested and do less upstream proxy requests for the source image data