### PR TITLE
Make height or width optional

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,6 +39,16 @@ http {
         proxy_cache_valid      200  1d;
         proxy_cache_use_stale  error timeout invalid_header updating http_500 http_502 http_503 http_504;
 
+        if ($uri ~ "^/([1-9][0-9]{0,2})x/") {
+            set $width $1;
+            set $height -;
+        }
+
+        if ($uri ~ "^/x([1-9][0-9]{0,2})/") {
+            set $width -;
+            set $height $1;
+        }
+
         if ($uri ~ "^/([1-9][0-9]{0,2})x([1-9][0-9]{0,2})/") {
             set $width $1;
             set $height $2;
@@ -46,8 +56,8 @@ http {
 
         # Proxy new panoptes-uploads-staging requests to Azure storage
         # e.g. https://panoptes-uploads-staging.zooniverse.org/workflow_attached_image/704a79c1-e728-4ab3-828d-e398fba69ec3.jpeg
-        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads-staging.zooniverse.org/.+$" {
-            rewrite "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads-staging.zooniverse.org(/.*)$" $1 break;
+        location ~ "^/[0-9]{0,3}x[0-9]{0,3}/panoptes-uploads-staging.zooniverse.org/.+$" {
+            rewrite "^/[0-9]{0,3}x[0-9]{0,3}/panoptes-uploads-staging.zooniverse.org(/.*)$" $1 break;
             resolver 8.8.8.8;
             proxy_pass https://panoptesuploadsstaging.blob.core.windows.net/public$uri?$query_string;
             proxy_set_header       Host panoptesuploadsstaging.blob.core.windows.net;
@@ -57,8 +67,8 @@ http {
 
         # Proxy old panoptes-uploads staging requests to Azure storage
         # e.g. https://panoptes-uploads.zooniverse.org/staging/workflow_attached_image/362d0a60-84a1-41db-9ea9-a42789f492c8.jpeg
-        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/staging/.+$" {
-            rewrite "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/staging(/.*)$" $1 break;
+        location ~ "^/[0-9]{0,3}x[0-9]{0,3}/panoptes-uploads.zooniverse.org/staging/.+$" {
+            rewrite "^/[0-9]{0,3}x[0-9]{0,3}/panoptes-uploads.zooniverse.org/staging(/.*)$" $1 break;
             resolver 8.8.8.8;
             proxy_pass https://panoptesuploadsstaging.blob.core.windows.net/public$uri?$query_string;
             proxy_set_header       Host panoptesuploadsstaging.blob.core.windows.net;
@@ -69,8 +79,8 @@ http {
         # Proxy panoptes-uploads production requests to Azure storage
         # e.g. https://panoptes-uploads.zooniverse.org/production/workflow_attached_image/c3303c4d-28b2-453c-882c-63a95a5c41bc.jpeg
         #      https://panoptes-uploads.zooniverse.org/workflow_attached_image/6769554f-9079-41c8-acfc-393737a4972f.jpeg
-        location ~ "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org/.+$" {
-            rewrite "^/[1-9][0-9]{0,2}x[1-9][0-9]{0,2}/panoptes-uploads.zooniverse.org(?:/production)?(/.*)$" $1 break;
+        location ~ "^/[0-9]{0,3}x[0-9]{0,3}/panoptes-uploads.zooniverse.org/.+$" {
+            rewrite "^/[0-9]{0,3}x[0-9]{0,3}/panoptes-uploads.zooniverse.org(?:/production)?(/.*)$" $1 break;
             resolver 8.8.8.8;
             proxy_pass https://panoptesuploads.blob.core.windows.net/public$uri?$query_string;
             proxy_set_header       Host panoptesuploads.blob.core.windows.net;
@@ -80,7 +90,7 @@ http {
 
         # proxy all other requests to the azure zoonversestatic storage account, $web container
         location / {
-            rewrite "^/([1-9][0-9]{0,2}x[1-9][0-9]{0,2})(/.*)$" $2 break;
+            rewrite "^/([0-9]{0,3}x[0-9]{0,3})(/.*)$" $2 break;
             resolver 8.8.8.8;
             proxy_http_version 1.1;
             proxy_pass https://zooniversestatic.z13.web.core.windows.net$uri?$query_string;


### PR DESCRIPTION
Allow either height or width to be optional in the URL. URLs like `/x300/` set the width to `-`and resize only on the height. URLs like `/300x/` set the height to `-` and resize only on width.

>resize width height
    proportionally reduces an image to the specified sizes. To reduce by only one dimension, another dimension can be specified as “-”. In case of an error, the server will return code 415 (Unsupported Media Type). Parameter values can contain variables. When used along with the rotate parameter, the rotation happens after reduction. 

https://nginx.org/en/docs/http/ngx_http_image_filter_module.html#image_filter